### PR TITLE
Add MCP module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "hackerone-graphql-mcp-server"]
-	path = hackerone-graphql-mcp-server
-	url = https://github.com/Hacker0x01/hackerone-graphql-mcp-server
+        path = hackerone-graphql-mcp-server
+        url = https://github.com/Hacker0x01/hackerone-graphql-mcp-server
+[submodule "modules/mcp/hackerone-graphql-mcp-server"]
+        path = modules/mcp/hackerone-graphql-mcp-server
+        url = https://github.com/Hacker0x01/hackerone-graphql-mcp-server

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -9,6 +9,7 @@ Subfolders:
 - `report_parser/` - parse HackerOne report data
 - `summarizer/` - send reports to local LLM
 - `sync_engine/` - fetch data from HackerOne
+- `mcp/` - HackerOne GraphQL MCP server
 - `utils/` - shared helper utilities
 
 Add new modules as peer directories and document them similarly.

--- a/modules/mcp/AGENTS.md
+++ b/modules/mcp/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+Provides the HackerOne GraphQL MCP server used by BigShot. The server code lives in the `hackerone-graphql-mcp-server` submodule.
+
+Files:
+- `hackerone-graphql-mcp-server/` - Docker-based MCP server implementation.
+- `agent_notes.md` - ongoing notes for MCP integration.
+
+Refer to the README for setup details.

--- a/modules/mcp/agent_notes.md
+++ b/modules/mcp/agent_notes.md
@@ -1,0 +1,1 @@
+# MCP module notes


### PR DESCRIPTION
## Summary
- document MCP server in AGENTS
- add mcp folder to modules list
- track MCP server as a submodule under modules/mcp

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870584127d8833282e280454bfe0864